### PR TITLE
Free update

### DIFF
--- a/lib/geohash_helper/geohash_helper.rb
+++ b/lib/geohash_helper/geohash_helper.rb
@@ -18,10 +18,6 @@ module GeohashHelper
            :neighbors, :pointer
 
     def self.release(ptr)
-      tmp = GeohashHelper::GeoHashRadius.new(ptr)
-      GeohashHelper.free_object(tmp[:hash])
-      GeohashHelper::GeoHashArea.release(tmp[:area])
-      GeohashHelper::GeoHashArea.release(tmp[:neighbors])
       GeohashHelper.free_object(ptr)
     end
   end
@@ -52,10 +48,6 @@ module GeohashHelper
            :latitude, :pointer
 
     def self.release(ptr)
-      tmp = GeohashHelper::GeoHashArea.new(ptr)
-      GeohashHelper.free_object(tmp[:hash])
-      GeohashHelper.free_object(tmp[:longitude])
-      GeohashHelper.free_object(tmp[:latitude])
       GeohashHelper.free_object(ptr)
     end
   end
@@ -72,15 +64,6 @@ module GeohashHelper
            :south_west,  :pointer
 
     def self.release(ptr)
-      tmp = GeohashHelper::GeoHashNeighbors.new(ptr)
-      GeohashHelper.free_object(tmp[:north])
-      GeohashHelper.free_object(tmp[:east])
-      GeohashHelper.free_object(tmp[:west])
-      GeohashHelper.free_object(tmp[:south])
-      GeohashHelper.free_object(tmp[:north_east])
-      GeohashHelper.free_object(tmp[:south_east])
-      GeohashHelper.free_object(tmp[:north_west])
-      GeohashHelper.free_object(tmp[:south_west])
       GeohashHelper.free_object(ptr)
     end
   end


### PR DESCRIPTION
In C, when you plan to free a pointer that points to other pointers, you have to free those referenced pointers first. However, these ManagedStructs are garbage collected, so I was freeing them more than I needed to.
